### PR TITLE
Changed parameter names in Audit Configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,6 +38,6 @@ The following table provides quick links to help you get started.
 
 For questions or comments about OpenShift documentation:
 
-* OpenShift team members can be found on the http://webchat.freenode.net/?randomnick=1&channels=openshift&uio=d4[#openshift] and http://webchat.freenode.net/?randomnick=1&channels=openshift-dev&uio=d4[#openshift-dev channels] on http://www.freenode.net/[FreeNode].
+* OpenShift team members can be found on the http://webchat.freenode.net/?randomnick=1&channels=openshift&uio=d4[#openshift] and http://webchat.freenode.net/?randomnick=1&channels=openshift-dev&uio=d4[#openshift-dev] channels on http://www.freenode.net/[FreeNode].
 * You can also join the http://lists.openshift.redhat.com/openshiftmm/listinfo/users[Users] or http://lists.openshift.redhat.com/openshiftmm/listinfo/dev[Developers] mailing list.
 * Send an email to the OpenShift documentation team at openshift-docs@redhat.com.

--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -375,8 +375,10 @@ Topics:
         File: ceph_example
       - Name: Complete Example Using GlusterFS
         File: gluster_example
-      - Name: Dynamic Provisioning Example Using GlusterFS
+      - Name: Dynamic Provisioning Example Using Containerized GlusterFS
         File: gluster_dynamic_example
+      - Name: Dynamic Provisioning Example Using Dedicated GlusterFS
+        File: dedicated_gluster_dynamic_example
       - Name: Mounting Volumes To Privileged Pods
         File: privileged_pod_storage
       - Name: Backing Docker Registry with GlusterFS Storage

--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -687,6 +687,8 @@ Topics:
     File: jobs
   - Name: Cron Jobs
     File: cron_jobs
+  - Name: Create from URL
+    File: create_from_url
   - Name: Revision History
     File: revhistory_dev_guide
     Distros: openshift-enterprise,openshift-dedicated

--- a/admin_guide/ipsec.adoc
+++ b/admin_guide/ipsec.adoc
@@ -83,7 +83,7 @@ key files into a *_PKCS#12_* file, which is a common file format for multiple
 certificates and keys:
 +
 ----
-openssl pkcs12 -export \
+# openssl pkcs12 -export \
   -in /path/to/client-certificate \
   -inkey /path/to/private-key \
   -certfile /path/to/certificate-authority \
@@ -220,13 +220,13 @@ conn <other_node_hostname>
 All nodes within the cluster need to allow IPSec related network traffic. This
 includes IP protocol numbers 50 and 51 as well as UDP port 500.
 
-For example, if the cluster nodes communicate over interface eth0:
-+
----
+For example, if the cluster nodes communicate over interface `eth0`:
+
+----
 -A OS_FIREWALL_ALLOW -i eth0 -p 50 -j ACCEPT
 -A OS_FIREWALL_ALLOW -i eth0 -p 51 -j ACCEPT
 -A OS_FIREWALL_ALLOW -i eth0 -p udp --dport 500 -j ACCEPT
----
+----
 
 [NOTE]
 ====
@@ -241,13 +241,13 @@ to normal cluster deployments.
 and begin encrypting:
 +
 ----
-systemctl start ipsec
+# systemctl start ipsec
 ----
 
 . Enable the *ipsec* service to start on boot:
 +
 ----
-systemctl enable ipsec
+# systemctl enable ipsec
 ----
 
 [[admin-guide-ipsec-troubleshooting]]

--- a/admin_guide/ipsec.adoc
+++ b/admin_guide/ipsec.adoc
@@ -18,7 +18,7 @@ Internet Protocol (IP).
 
 This topic shows how to secure communication of an entire IP subnet from which
 the {product-title} hosts receive their IP addresses, including all cluster
-management and pod data traffic. 
+management and pod data traffic.
 
 [NOTE]
 ====
@@ -46,11 +46,11 @@ xref:../admin_guide/ipsec.adoc#admin-guide-ipsec-opportunistic-group-configurati
 group functionality] is required, then *libreswan* version 3.19 or later is
 required.
 
-link:../install_config/configuring_sdn.html[Configure the SDN] MTU to allow
-space for the IPSec header. In the configuration described here IPSec requires
-62 bytes. If the cluster is operating on an ethernet network with an MTU of
-1500 then the SDN MTU should be 1388, to allow for the overhead of IPSec and
-the SDN encapsulation.
+xref:../install_config/configuring_sdn.adoc#install-config-configuring-sdn[Configure the SDN]
+MTU to allow space for the IPSec header. In the configuration described here
+IPSec requires 62 bytes. If the cluster is operating on an ethernet network with
+an MTU of 1500 then the SDN MTU should be 1388, to allow for the overhead of
+IPSec and the SDN encapsulation.
 
 [[admin-guide-ipsec-certificates]]
 === Step 2: Certificates
@@ -255,7 +255,7 @@ systemctl enable ipsec
 When authentication cannot be completed between two hosts, you will not be able
 to ping between them, because all IP traffic will be rejected. If the `clear`
 policy is not configured correctly, you will also not be able to SSH to the host
-from another host in the cluster. 
+from another host in the cluster.
 
 You can use the `ipsec status` command to check that the `clear` and `private`
 policies have been loaded.

--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -445,17 +445,17 @@ where:
 - {product-title} is installed in a cloud provider where internal hostnames are not configured/resolvable by all hosts.
 - The node's IP from the master's perspective is not the same as the node's IP from its own perspective.
 
-Configuring the `*openshift_node_set_node_ip*` Ansible variable
+Configuring the `*openshift_set_node_ip*` Ansible variable
 forces node traffic through an interface other than the default network
 interface.
 
 To change the node traffic interface:
 
-. Set the `*openshift_node_set_node_ip*` Ansible variable to `true`.
+. Set the `*openshift_set_node_ip*` Ansible variable to `true`.
 . Set the `*openshift_ip*` to the IP address for the node you want to configure.
 [NOTE]
 ====
-Although  `*openshift_node_set_node_ip*` can be useful as a workaround for the
+Although  `*openshift_set_node_ip*` can be useful as a workaround for the
 cases stated in this section, it is generally not suited for production
 environments. This is because the node will no longer function properly if it
 receives a new IP address.

--- a/admin_guide/manage_nodes.adoc
+++ b/admin_guide/manage_nodes.adoc
@@ -402,7 +402,7 @@ kubeletArguments:
     - "80"
 ----
 
-<1> Number of pods that can run on this kubelet.
+<1> xref:../admin_guide/manage_nodes.adoc#admin-guide-max-pods-per-node[Maximum number of pods that can run on this kubelet].
 <2> Resolver configuration file used as the basis for the container DNS
 resolution configuration.
 <3> The percent of disk usage after which image garbage collection is always run.
@@ -426,6 +426,42 @@ installation] using the `*openshift_node_kubelet_args*` variable. For example:
 openshift_node_kubelet_args={'max-pods': ['40'], 'resolv-conf': ['/etc/resolv.conf'],  'image-gc-high-threshold': ['90'], 'image-gc-low-threshold': ['80']}
 ----
 ====
+
+[[admin-guide-max-pods-per-node]]
+=== Setting Maximum Pods Per Node
+
+In the *_/etc/origin/node/node-config.yaml_* file, two parameters control the
+maximum number of pods that can be scheduled to a node: `pods-per-core` and
+`max-pods`. When both options are in use, the lower of the two limits the number
+of pods on a node.
+
+`pods-per-core` sets the number of pods the node can run based on the number of
+processor cores on the node. For example, if `pods-per-core` is set to `10` on
+a node with 4 processor cores, the maxiumum number of pods allowed on the node
+will be 40.
+
+====
+----
+kubeletArguments:
+  pods-per-core:
+    - 10
+----
+====
+
+`max-pods` sets the number of pods the node can run to a fixed value, regardless
+of the properties of the node.
+
+====
+----
+kubeletArguments:
+  max-pods:
+    - 250
+----
+====
+
+Using the above example, the default value for `pods-per-core` is `10` and the
+default value for `max-pods` is `250`. This means that unless the node has 25
+cores or more, by default, `pods-per-core` will be the limiting factor.
 
 [[manage-node-change-node-traffic-interface]]
 == Changing Node Traffic Interface

--- a/admin_guide/overcommit.adoc
+++ b/admin_guide/overcommit.adoc
@@ -198,6 +198,41 @@ quota.openshift.io/cluster-resource-override-enabled: "false"
 In an overcommitted environment, it is important to properly configure your node
 to provide best system behavior.
 
+[[max-pods-per-node]]
+=== Setting Maximum Pods Per Node
+
+There are two flags that control the number of pods that can be scheduled to the
+node: `pods-per-core` and `max-pods`.  These flags interact and only the *lower*
+of the two will effectively limit the number of pods on a node.
+
+`pods-per-core` sets the number of pods the node can run based on the number of
+processor cores on the node. As an example, if `pods-per-core` is set to `10` on
+a node with 4 processor cores, the maxiumum number of pods allowed on the node
+will be 40.
+
+====
+----
+kubeletArguments:
+  pods-per-core:
+    - 10
+----
+====
+
+`max-pods` sets the number of pods the node can run to a fixed value, regardless
+of the properties of the node.
+
+====
+----
+kubeletArguments:
+  max-pods:
+    - 250
+----
+====
+
+The default value for `pods-per-core` is `10` and the default value for `max-pods` is `250`.
+This means that unless the node has 25 cores or more, by default, `pods-per-core` will be
+the limiting factor.
+
 [[enforcing-cpu-limits]]
 === Enforcing CPU Limits
 

--- a/admin_guide/overcommit.adoc
+++ b/admin_guide/overcommit.adoc
@@ -198,41 +198,6 @@ quota.openshift.io/cluster-resource-override-enabled: "false"
 In an overcommitted environment, it is important to properly configure your node
 to provide best system behavior.
 
-[[max-pods-per-node]]
-=== Setting Maximum Pods Per Node
-
-There are two flags that control the number of pods that can be scheduled to the
-node: `pods-per-core` and `max-pods`.  These flags interact and only the *lower*
-of the two will effectively limit the number of pods on a node.
-
-`pods-per-core` sets the number of pods the node can run based on the number of
-processor cores on the node. As an example, if `pods-per-core` is set to `10` on
-a node with 4 processor cores, the maxiumum number of pods allowed on the node
-will be 40.
-
-====
-----
-kubeletArguments:
-  pods-per-core:
-    - 10
-----
-====
-
-`max-pods` sets the number of pods the node can run to a fixed value, regardless
-of the properties of the node.
-
-====
-----
-kubeletArguments:
-  max-pods:
-    - 250
-----
-====
-
-The default value for `pods-per-core` is `10` and the default value for `max-pods` is `250`.
-This means that unless the node has 25 cores or more, by default, `pods-per-core` will be
-the limiting factor.
-
 [[enforcing-cpu-limits]]
 === Enforcing CPU Limits
 

--- a/admin_guide/seccomp.adoc
+++ b/admin_guide/seccomp.adoc
@@ -66,7 +66,7 @@ the security constraints of an individual system.
 To create your own custom profile, create a file on every node in the
 `seccomp-profile-root` directory.
 +
-If you are using the default *runtime/default* profile, you do not need to
+If you are using the default *docker/default* profile, you do not need to
 create one.
 
 . Configure your nodes to use the *seccomp-profile-root* where your profiles
@@ -98,15 +98,15 @@ default.
 +
 The allowable formats of the *seccompProfiles* field include:
 +
-* *runtime/default*: the default profile for the container runtime (no profile required)
+* *docker/default*: the default profile for the container runtime (no profile required)
 * *unconfined*: unconfined profile, and disables seccomp
 * *localhost/<profile-name>*: the profile installed to the node's local seccomp profile root
 +
-For example, if you are using the default *runtime/default* profile, configure the *restricted* SCC with:
+For example, if you are using the default *docker/default* profile, configure the *restricted* SCC with:
 +
 ----
 seccompProfiles:
-- runtime/default
+- docker/default
 ----
 
 [[seccomp-configuring-openshift-with-custom-seccomp]]

--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -229,6 +229,7 @@ $ oc set env dc/router HAPROXY_ROUTER_SYSLOG_ADDRESS=127.0.0.1 HAPROXY_ROUTER_LO
 |`*ROUTER_SERVICE_NAMESPACE*` |  | The namespace the router identifies itself in the in route status. Required if `ROUTER_SERVICE_NAME` is used.
 |`*ROUTER_SERVICE_NO_SNI_PORT*` | 10443 | Internal port for some front-end to back-end communication (see note below).
 |`*ROUTER_SERVICE_SNI_PORT*` | 10444 | Internal port for some front-end to back-end communication (see note below).
+|`*ROUTER_SLOWLORIS_HTTP_KEEPALIVE*` | 300s | Set the maximum time to wait for a new HTTP request to appear. If this is set too low, it can confuse browers/apps not expected a small keep alive.
 |`*ROUTER_SLOWLORIS_TIMEOUT*` | 10s | Length of time the transmission of an HTTP request can take.
 |`*ROUTER_SUBDOMAIN*`|  | The template that should be used to generate the hostname for a route without spec.host (e.g. `${name}-${namespace}.myapps.mycompany.com`).
 |`*ROUTER_SYSLOG_ADDRESS*` |  | Address to send log messages. Disabled if empty.

--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -229,9 +229,9 @@ $ oc set env dc/router HAPROXY_ROUTER_SYSLOG_ADDRESS=127.0.0.1 HAPROXY_ROUTER_LO
 |`*ROUTER_SERVICE_NAMESPACE*` |  | The namespace the router identifies itself in the in route status. Required if `ROUTER_SERVICE_NAME` is used.
 |`*ROUTER_SERVICE_NO_SNI_PORT*` | 10443 | Internal port for some front-end to back-end communication (see note below).
 |`*ROUTER_SERVICE_SNI_PORT*` | 10444 | Internal port for some front-end to back-end communication (see note below).
-|`*ROUTER_SLOWLORIS_HTTP_KEEPALIVE*` | 300s | Set the maximum time to wait for a new HTTP request to appear. If this is set too low, it can confuse browers/apps not expected a small keep alive.
+|`*ROUTER_SLOWLORIS_HTTP_KEEPALIVE*` | 300s | Set the maximum time to wait for a new HTTP request to appear. If this is set too low, it can confuse browsers and applications not expecting a small `keepalive` value.
 |`*ROUTER_SLOWLORIS_TIMEOUT*` | 10s | Length of time the transmission of an HTTP request can take.
-|`*ROUTER_SUBDOMAIN*`|  | The template that should be used to generate the hostname for a route without spec.host (e.g. `${name}-${namespace}.myapps.mycompany.com`).
+|`*ROUTER_SUBDOMAIN*`|  | The template that should be used to generate the host name for a route without spec.host (e.g. `${name}-${namespace}.myapps.mycompany.com`).
 |`*ROUTER_SYSLOG_ADDRESS*` |  | Address to send log messages. Disabled if empty.
 |`*ROUTER_TCP_BALANCE_SCHEME*` | source | Load-balancing strategy for multiple endpoints for pass-through routes. Available options are `source`, `roundrobin`, or `leastconn`.
 |`*ROUTER_LOAD_BALANCE_ALGORITHM*` | leastconn | Load-balancing strategy routes with multiple endpoints. Available options are `source`, `roundrobin`, and `leastconn`.
@@ -239,8 +239,8 @@ $ oc set env dc/router HAPROXY_ROUTER_SYSLOG_ADDRESS=127.0.0.1 HAPROXY_ROUTER_LO
 |`*ROUTE_LABELS*` |  | A label selector to apply to the routes to watch, empty means all.
 |`*STATS_PASSWORD*` |  | The password needed to access router stats (if the router implementation supports it).
 |`*STATS_PORT*` |  | Port to expose statistics on (if the router implementation supports it).  If not set, stats are not exposed.
-|`*STATS_USERNAME*` |  | The username needed to access router stats (if the router implementation supports it).
-|`*TEMPLATE_FILE*` | `/var/lib/haproxy/conf/custom/haproxy-config-custom.template` | The path to the haproxy template file (in the image).
+|`*STATS_USERNAME*` |  | The user name needed to access router stats (if the router implementation supports it).
+|`*TEMPLATE_FILE*` | `/var/lib/haproxy/conf/custom/haproxy-config-custom.template` | The path to the HAproxy template file (in the image).
 |`*RELOAD_INTERVAL*` | 12s | The minimum frequency the router is allowed to reload to accept new changes.
 |===
 

--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -1073,135 +1073,110 @@ link:https://github.com/openshift/origin/blob/master/images/router/clear-route-s
 script].
 
 
-[[router-domain-policy]]
-== Allowing/Denying certain Domains in Routes
+[[architecture-core-concepts-routes-deny-allow]]
+== Denying or Allowing Certain Domains in Routes
 
-A router can be configured to allow only a specific subset of domains or
-deny specific domains from the host names in a route. This policy is set
-using the `ROUTER_DENIED_DOMAINS` and/or `ROUTER_ALLOWED_DOMAINS`
-environment variables.
-If these variables are specified, the domains listed in the
-`ROUTER_DENIED_DOMAINS` are not allowed in any routes. And the domains
-liste in `ROUTER_ALLOWED_DOMAINS` are the only ones allowed in any routes.
-Note that the domains in the list of denied domains take precedence over
-the list of allowed domains.
-The order of precedence is to first check the deny list (if any) and if
-the host name is not in the list of denied domains, only then check the
-list of allowed domains. The list of allowed domains on the other hand is
-more restrictive and ensures that the router only admits routes with hosts
-that belong to that list.
+A router can be configured to deny or allow a specific subset of domains from
+the host names in a route using the `ROUTER_DENIED_DOMAINS` and
+`ROUTER_ALLOWED_DOMAINS` environment variables.
 
-.Router run with just a list of denied domains
-====
+[cols="2"]
+|===
 
-----
-$ oadm router denrouter ...
-$ oc set env dc/denrouter ROUTER_DENIED_DOMAINS="open.header.test, openshift.org, block.it" <1>
-----
+|`*ROUTER_DENIED_DOMAINS*` | Domains listed are not allowed in any indicated routes.
+|`*ROUTER_ALLOWED_DOMAINS*` | Only the domains listed are allowed in any indicated routes.
 
-----
-<1> Will block any routes where the host name is set to
-    `[*.]open.header.test`, `[*.]openshift.org` and `[*.]block.it`.
+|===
 
-The examples below indicate whether or not the `denrouter` will admit or
-deny a route based on the route's host name.
-----
-$ oc expose service/<name> --hostname="open.header.test"       # Denied.
+The domains in the list of denied domains take precedence over the list of
+allowed domains. Meaning {product-title} first checks the deny list (if
+applicable), and if the host name is not in the list of denied domains, it then
+checks the list of allowed domains. However, the list of allowed domains is more
+restrictive, and ensures that the router only admits routes with hosts that
+belong to that list.
 
-$ oc expose service/<name> --hostname="www.open.header.test"   # Denied.
-
-$ oc expose service/<name> --hostname="foo.header.test"        # Admitted.
-
-$ oc expose service/<name> --hostname="block.it"               # Denied.
-
-$ oc expose service/<name> --hostname="franco.baresi.block.it" # Denied.
-
-$ oc expose service/<name> --hostname="www.allow.it"           # Allowed.
-
-$ oc expose service/<name> --hostname="www.openshift.test"     # Allowed.
-
-$ oc expose service/<name> --hostname="openshift.org"          # Denied.
-
-$ oc expose service/<name> --hostname="api.openshift.org"      # Denied.
-----
-====
-
-
-.Router run with just a list of allowed domains
-====
+For example, to deny the `[*.]open.header.test`, `[*.]openshift.org` and
+`[*.]block.it` routes for the `myrouter` route:
 
 ----
-$ oadm router allrouter ...
-$ oc set env dc/allrouter ROUTER_ALLOWED_DOMAINS="stickshift.org, kates.net" <1>
+$ oadm router myrouter ...
+$ oc set env dc/myrouter ROUTER_DENIED_DOMAINS="open.header.test, openshift.org, block.it"
 ----
 
+This means that `myrouter` will admit the following based on the route's name:
+
 ----
-<1> Will block any routes where the host name is _not_ set to
-    `[*.]stickshift.org` or `[*.]kates.net`.
-
-The examples below indicate whether or not the `allrouter` will admit or
-deny a route based on the route's host name.
+$ oc expose service/<name> --hostname="foo.header.test" 
+$ oc expose service/<name> --hostname="www.allow.it"
+$ oc expose service/<name> --hostname="www.openshift.test"
 ----
-$ oc expose service/<name> --hostname="www.open.header.test"   # Denied.
 
-$ oc expose service/<name> --hostname="stickshift.org"         # Admitted.
+However, `myrouter` will deny the following:
 
-$ oc expose service/<name> --hostname="www.stickshift.org"     # Admitted.
-
-$ oc expose service/<name> --hostname="a.b.c.stickshift.org"   # Allowed.
-
-$ oc expose service/<name> --hostname="drive.ottomatic.org"    # Denied.
-
-$ oc expose service/<name> --hostname="www.wayless.com"        # Denied.
-
-$ oc expose service/<name> --hostname="www.deny.it"            # Denied.
-
-$ oc expose service/<name> --hostname="kates.net"              # Allowed.
-
-$ oc expose service/<name> --hostname="api.kates.net"          # Allowed.
-
-$ oc expose service/<name> --hostname="erno.r.kube.kates.net"  # Allowed.
 ----
-====
+$ oc expose service/<name> --hostname="open.header.test"
+$ oc expose service/<name> --hostname="www.open.header.test"
+$ oc expose service/<name> --hostname="block.it"
+$ oc expose service/<name> --hostname="franco.baresi.block.it"
+$ oc expose service/<name> --hostname="openshift.org"
+$ oc expose service/<name> --hostname="api.openshift.org"
+----
 
+Alternatively, to block any routes where the host name is _not_ set to `[*.]stickshift.org` or `[*.]kates.net`:
 
-.Router run with a both a list of allowed and denied domains
-====
+----
+$ oadm router myrouter ...
+$ oc set env dc/myrouter ROUTER_ALLOWED_DOMAINS="stickshift.org, kates.net"
+----
+
+This means that the `myrouter` router will admit:
+
+----
+$ oc expose service/<name> --hostname="stickshift.org"
+$ oc expose service/<name> --hostname="www.stickshift.org" 
+$ oc expose service/<name> --hostname="kates.net" 
+$ oc expose service/<name> --hostname="api.kates.net"
+$ oc expose service/<name> --hostname="erno.r.kube.kates.net"
+----
+
+However, `myrouter` will deny the following:
+
+----
+$ oc expose service/<name> --hostname="www.open.header.test"
+$ oc expose service/<name> --hostname="drive.ottomatic.org"
+$ oc expose service/<name> --hostname="www.wayless.com"
+$ oc expose service/<name> --hostname="www.deny.it"
+----
+
+To implement both scenarios, run:
 
 ----
 $ oadm router adrouter ...
 $ oc env dc/adrouter ROUTER_ALLOWED_DOMAINS="openshift.org, kates.net" \
-    ROUTER_DENIED_DOMAINS="ops.openshift.org, metrics.kates.net" <1>
+    ROUTER_DENIED_DOMAINS="ops.openshift.org, metrics.kates.net"
 ----
 
+This will allow any routes where the host name is set to `[*.]openshift.org` or
+`[*.]kates.net`, and not allow any routes where the host name is set to
+`[*.]ops.openshift.org` or `[*.]metrics.kates.net`.
+
+Therefore, the following will be denied:
+
 ----
-<1> Will block any routes where the host name is set to `[*.]openshift.org`
-    or `[*.]kates.net`. And will not allow any routes where the host name
-    is set to `[*.]ops.openshift.org` or `[*.]metrics.kates.net`.
-
-The examples below indicate whether or not the `adrouter` will admit or
-deny a route based on the route's host name.
+$ oc expose service/<name> --hostname="www.open.header.test"
+$ oc expose service/<name> --hostname="ops.openshift.org"
+$ oc expose service/<name> --hostname="log.ops.openshift.org"
+$ oc expose service/<name> --hostname="www.block.it"
+$ oc expose service/<name> --hostname="metrics.kates.net"
+$ oc expose service/<name> --hostname="int.metrics.kates.net"
 ----
-$ oc expose service/<name> --hostname="www.open.header.test"   # Denied.
 
-$ oc expose service/<name> --hostname="openshift.org"          # Admitted.
+However, the following will be allowed:
 
-$ oc expose service/<name> --hostname="api.openshift.org"      # Admitted.
-
-$ oc expose service/<name> --hostname="m.api.openshift.org"    # Allowed.
-
-$ oc expose service/<name> --hostname="ops.openshift.org"      # Denied.
-
-$ oc expose service/<name> --hostname="log.ops.openshift.org"  # Denied.
-
-$ oc expose service/<name> --hostname="www.block.it"           # Denied.
-
-$ oc expose service/<name> --hostname="kates.net"              # Allowed.
-
-$ oc expose service/<name> --hostname="api.kates.net"          # Allowed.
-
-$ oc expose service/<name> --hostname="metrics.kates.net"      # Denied.
-
-$ oc expose service/<name> --hostname="int.metrics.kates.net"  # Denied.
 ----
-====
+$ oc expose service/<name> --hostname="openshift.org"
+$ oc expose service/<name> --hostname="api.openshift.org"
+$ oc expose service/<name> --hostname="m.api.openshift.org"
+$ oc expose service/<name> --hostname="kates.net"
+$ oc expose service/<name> --hostname="api.kates.net"
+----

--- a/architecture/core_concepts/routes.adoc
+++ b/architecture/core_concepts/routes.adoc
@@ -1062,3 +1062,137 @@ The routers do not clear the `route status` field. To remove the stale entries
 in the route status, use the
 link:https://github.com/openshift/origin/blob/master/images/router/clear-route-status.sh[clear-route-status
 script].
+
+
+[[router-domain-policy]]
+== Allowing/Denying certain Domains in Routes
+
+A router can be configured to allow only a specific subset of domains or
+deny specific domains from the host names in a route. This policy is set
+using the `ROUTER_DENIED_DOMAINS` and/or `ROUTER_ALLOWED_DOMAINS`
+environment variables.
+If these variables are specified, the domains listed in the
+`ROUTER_DENIED_DOMAINS` are not allowed in any routes. And the domains
+liste in `ROUTER_ALLOWED_DOMAINS` are the only ones allowed in any routes.
+Note that the domains in the list of denied domains take precedence over
+the list of allowed domains.
+The order of precedence is to first check the deny list (if any) and if
+the host name is not in the list of denied domains, only then check the
+list of allowed domains. The list of allowed domains on the other hand is
+more restrictive and ensures that the router only admits routes with hosts
+that belong to that list.
+
+.Router run with just a list of denied domains
+====
+
+----
+$ oadm router denrouter ...
+$ oc set env dc/denrouter ROUTER_DENIED_DOMAINS="open.header.test, openshift.org, block.it" <1>
+----
+
+----
+<1> Will block any routes where the host name is set to
+    `[*.]open.header.test`, `[*.]openshift.org` and `[*.]block.it`.
+
+The examples below indicate whether or not the `denrouter` will admit or
+deny a route based on the route's host name.
+----
+$ oc expose service/<name> --hostname="open.header.test"       # Denied.
+
+$ oc expose service/<name> --hostname="www.open.header.test"   # Denied.
+
+$ oc expose service/<name> --hostname="foo.header.test"        # Admitted.
+
+$ oc expose service/<name> --hostname="block.it"               # Denied.
+
+$ oc expose service/<name> --hostname="franco.baresi.block.it" # Denied.
+
+$ oc expose service/<name> --hostname="www.allow.it"           # Allowed.
+
+$ oc expose service/<name> --hostname="www.openshift.test"     # Allowed.
+
+$ oc expose service/<name> --hostname="openshift.org"          # Denied.
+
+$ oc expose service/<name> --hostname="api.openshift.org"      # Denied.
+----
+====
+
+
+.Router run with just a list of allowed domains
+====
+
+----
+$ oadm router allrouter ...
+$ oc set env dc/allrouter ROUTER_ALLOWED_DOMAINS="stickshift.org, kates.net" <1>
+----
+
+----
+<1> Will block any routes where the host name is _not_ set to
+    `[*.]stickshift.org` or `[*.]kates.net`.
+
+The examples below indicate whether or not the `allrouter` will admit or
+deny a route based on the route's host name.
+----
+$ oc expose service/<name> --hostname="www.open.header.test"   # Denied.
+
+$ oc expose service/<name> --hostname="stickshift.org"         # Admitted.
+
+$ oc expose service/<name> --hostname="www.stickshift.org"     # Admitted.
+
+$ oc expose service/<name> --hostname="a.b.c.stickshift.org"   # Allowed.
+
+$ oc expose service/<name> --hostname="drive.ottomatic.org"    # Denied.
+
+$ oc expose service/<name> --hostname="www.wayless.com"        # Denied.
+
+$ oc expose service/<name> --hostname="www.deny.it"            # Denied.
+
+$ oc expose service/<name> --hostname="kates.net"              # Allowed.
+
+$ oc expose service/<name> --hostname="api.kates.net"          # Allowed.
+
+$ oc expose service/<name> --hostname="erno.r.kube.kates.net"  # Allowed.
+----
+====
+
+
+.Router run with a both a list of allowed and denied domains
+====
+
+----
+$ oadm router adrouter ...
+$ oc env dc/adrouter ROUTER_ALLOWED_DOMAINS="openshift.org, kates.net" \
+    ROUTER_DENIED_DOMAINS="ops.openshift.org, metrics.kates.net" <1>
+----
+
+----
+<1> Will block any routes where the host name is set to `[*.]openshift.org`
+    or `[*.]kates.net`. And will not allow any routes where the host name
+    is set to `[*.]ops.openshift.org` or `[*.]metrics.kates.net`.
+
+The examples below indicate whether or not the `adrouter` will admit or
+deny a route based on the route's host name.
+----
+$ oc expose service/<name> --hostname="www.open.header.test"   # Denied.
+
+$ oc expose service/<name> --hostname="openshift.org"          # Admitted.
+
+$ oc expose service/<name> --hostname="api.openshift.org"      # Admitted.
+
+$ oc expose service/<name> --hostname="m.api.openshift.org"    # Allowed.
+
+$ oc expose service/<name> --hostname="ops.openshift.org"      # Denied.
+
+$ oc expose service/<name> --hostname="log.ops.openshift.org"  # Denied.
+
+$ oc expose service/<name> --hostname="www.block.it"           # Denied.
+
+$ oc expose service/<name> --hostname="kates.net"              # Allowed.
+
+$ oc expose service/<name> --hostname="api.kates.net"          # Allowed.
+
+$ oc expose service/<name> --hostname="metrics.kates.net"      # Denied.
+
+$ oc expose service/<name> --hostname="int.metrics.kates.net"  # Denied.
+----
+====

--- a/dev_guide/app_tutorials/maven_tutorial.adoc
+++ b/dev_guide/app_tutorials/maven_tutorial.adoc
@@ -30,7 +30,7 @@ to configure your build properly.
 
 Furthermore, make sure that you give each pod enough resources to function. You
 may have to
-xref:../../dev_guide/deployment#creating-a-deployment-configuration[edit the pod
+xref:../../dev_guide/deployments#creating-a-deployment-configuration[edit the pod
 template] in the Nexus deployment configuration to request more resources.
 
 [[nexus-setting-up-nexus]]

--- a/dev_guide/app_tutorials/maven_tutorial.adoc
+++ b/dev_guide/app_tutorials/maven_tutorial.adoc
@@ -68,8 +68,8 @@ and the password is *admin123*.
 [NOTE]
 ====
 Nexus comes pre-configured for the Central Repository, but you may need others
-for your application. For many Red Hat images, it is recommended to link:https://books.sonatype.com/nexus-book/reference/config-maven.html[add the
-*jboss-ga* repository] at link:https://maven.repository.redhat.com/ga/[Maven repository].
+for your application. For many Red Hat images, it is recommended to link:https://maven.repository.redhat.com/ga/[add the
+*jboss-ga* repository] at link:https://books.sonatype.com/nexus-book/reference/config-maven.html[Maven repository].
 ====
 
 [[nexus-using-probes-to-check-for-success]]

--- a/dev_guide/app_tutorials/maven_tutorial.adoc
+++ b/dev_guide/app_tutorials/maven_tutorial.adoc
@@ -30,7 +30,7 @@ to configure your build properly.
 
 Furthermore, make sure that you give each pod enough resources to function. You
 may have to
-xref:../../dev_guide/deployments#creating-a-deployment-configuration[edit the pod
+xref:../../dev_guide/deployments/how_deployments_work.adoc#creating-a-deployment-configuration[edit the pod
 template] in the Nexus deployment configuration to request more resources.
 
 [[nexus-setting-up-nexus]]

--- a/dev_guide/builds/build_strategies.adoc
+++ b/dev_guide/builds/build_strategies.adoc
@@ -525,3 +525,48 @@ spec:
     file to use, relative to the source `contextDir`.
     If `contextDir` is omitted, it defaults to the root of the repository.
     If `jenkinsfilePath` is omitted, it defaults to *_Jenkinsfile_*.
+
+[[jenkins-pipeline-strategy-environment]]
+=== Environment Variables
+
+To make environment variables available to the
+xref:../../architecture/core_concepts/builds_and_image_streams.adoc#pipeline-build[Pipeline build]
+process, you can add environment variables to the `jenkinsPipelineStrategy` definition
+of the `BuildConfig`.
+
+The environment variables defined there are set as parameters on the job in Jenkins associated with
+the `BuildConfig`. 
+
+For example:
+
+[source,yaml]
+----
+jenkinsPipelineStrategy:
+...
+  env:
+    - name: "FOO"
+      value: "BAR"
+
+----
+
+Specifics on the mapping between `BuildConfig` environment variables and Jenkins job parameters:
+
+* When a Jenkins job is created or updated based on changes to a Pipeline strategy `BuildConfig`, any environment
+variables in the `BuildConfig` are mapped to Jenkins job parameters definitions, where the default values for the Jenkins job parameters 
+definitions are the current values of the associated environment variables.
+* You can still add additional parameters (whose names differ from the names of the environment variables in the `BuildConfig`) 
+to the Jenkins job from the Jenkins console after the job's initial creation and they will be honored when builds are started for those Jenkins jobs.
+* How you start builds for the Jenkins job then dictates how the parameters are set.
+* If you start via `oc start-build`, the values of the environment variables in the `BuildConfig` are what the parameters are set
+to for the corresponding job instance.  Any changes you make to the parameters default values from the Jenkins console are ignored.
+The `BuildConfig` values take precedence.
+* If you start via `oc start-build -e`, the values for the environment variables specified in the `-e` option take precedence.  And if you
+specify an environment variable not listed in the `BuildConfig`, they will be added as a Jenkins job parameter definitions. And, again, any
+changes you make from the Jenkins console to the parameters corresponding to the environment variables are ignored.  The `BuildConfig`
+and what you specify via `oc start-build -e` takes precedence.
+* If you start the Jenkins job via the Jenkins console, then you can control the setting of the parameters via the Jenkins console as part
+of starting a build for the job.
+
+You can also manage environment variables defined in the `BuildConfig` with the
+xref:../../dev_guide/environment_variables.adoc#dev-guide-environment-variables[`oc set env`] command.
+

--- a/dev_guide/builds/index.adoc
+++ b/dev_guide/builds/index.adoc
@@ -47,7 +47,7 @@ xref:build_inputs.adoc#dev-guide-build-inputs[_build input_]:
 - xref:build_inputs.adoc#binary-source[Binary]
 - xref:build_inputs.adoc#image-source[Image]
 - xref:build_inputs.adoc#using-secrets-during-build[Input secrets]
-- xref:build_inputs.adoc#using-external-artifacts[External artifcats]
+- xref:build_inputs.adoc#using-external-artifacts[External artifacts]
 
 It is up to each build strategy to consider or ignore a certain type of source,
 as well as to determine how it is to be used. Binary and Git are mutually

--- a/dev_guide/create_from_url.adoc
+++ b/dev_guide/create_from_url.adoc
@@ -11,17 +11,16 @@
 
 toc::[]
 
-[[overview]]
 == Overview
 
 Create From URL is a function that allows you to construct a URL from an image
 stream, image tag, or template.
 
-Create from URL only works with image streams or templates from
-namespaces that have been explicitly whitelisted.  The whitelist contains
-the 'openshift' namespace by default.  To add namespaces to the whitelist, see
-xref:../install_config/web_console_customization.adoc#configuring-the-create-
-from-url-namespace-whitelist[Configuring the Create From URL Namespace Whitelist].
+Create from URL only works with image streams or templates from namespaces that
+have been explicitly whitelisted. The whitelist contains the `openshift`
+namespace by default. To add namespaces to the whitelist, see
+xref:../install_config/web_console_customization.adoc#configuring-the-create-from-url-namespace-whitelist[Configuring
+the Create From URL Namespace Whitelist].
 
 [[create-for-url-using-an-image-stream-and-image-tag]]
 == Using an Image Stream and Image Tag
@@ -32,24 +31,25 @@ from-url-namespace-whitelist[Configuring the Create From URL Namespace Whitelist
 [options="header"]
 |===
 |Name|Description|Required|Schema|Default
-|imageStream|The value metadata.name as defined in the image stream to be used.|
+|`imageStream`|The value `metadata.name` as defined in the image stream to be used.|
 true|string|
-|imageTag|The value spec.tags.name as defined in the image stream to be used.|
+|`imageTag`|The value `spec.tags.name` as defined in the image stream to be used.|
 true|string|
-|namespace|The name of the namespace containing the image stream and image tag
-to use.|false|string|openshift
-|name|Identifies the resources created for this application.|false|string|
-|sourceURI|The git repository URL containing the application source code.|false|
+|`namespace`|The name of the namespace containing the image stream and image tag
+to use.|false|string|`openshift`
+|`name`|Identifies the resources created for this application.|false|string|
+|`sourceURI`|The Git repository URL containing the application source code.|false|
 string|
-|sourceRef|The branch, tag, or commit for the application source code specified
-in sourceURI.|false|string|
-|contextDir|The subdirectory for the application source code specified in
-sourceURI, used as the context directory for the build.|false|string|
+|`sourceRef`|The branch, tag, or commit for the application source code specified
+in `sourceURI`.|false|string|
+|`contextDir`|The subdirectory for the application source code specified in
+`sourceURI`, used as the context directory for the build.|false|string|
 |===
 
 [NOTE]
 ====
-link:https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters[Reserved characters] in parameter values should be URL encoded.
+link:https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters[Reserved
+characters] in parameter values should be URL encoded.
 ====
 
 [[example-usage-of-an-image-stream-and-image-tag]]
@@ -67,16 +67,17 @@ link:https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_ch
 [options="header"]
 |===
 |Name|Description|Required|Schema|Default
-|template|The value of metadata.name as defined in the template to be used.|
+|`template`|The value of `metadata.name` as defined in the template to be used.|
 true|string|
-|templateParamsMap|A JSON parameters map containing the template parameter name
+|`templateParamsMap`|A JSON parameters map containing the template parameter name
 and corresponding value you wish to override.|false|JSON|
-|namespace|The name of the namespace containing the template to use.|false|string|openshift
+|`namespace`|The name of the namespace containing the template to use.|false|string|`openshift`
 |===
 
 [NOTE]
 ====
-link:https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters[Reserved characters] in parameter values should be URL encoded.
+link:https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters[Reserved
+characters] in parameter values should be URL encoded.
 ====
 
 [[example-usage-of-a-template]]

--- a/dev_guide/create_from_url.adoc
+++ b/dev_guide/create_from_url.adoc
@@ -1,0 +1,86 @@
+[[dev-guide-create-from-url]]
+= Create from URL
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+[[overview]]
+== Overview
+
+Create From URL is a function that allows you to construct a URL from an image
+stream, image tag, or template.
+
+Create from URL only works with image streams or templates from
+namespaces that have been explicitly whitelisted.  The whitelist contains
+the 'openshift' namespace by default.  To add namespaces to the whitelist, see
+xref:../install_config/web_console_customization.adoc#configuring-the-create-
+from-url-namespace-whitelist[Configuring the Create From URL Namespace Whitelist].
+
+[[create-for-url-using-an-image-stream-and-image-tag]]
+== Using an Image Stream and Image Tag
+
+[[image-stream-and-image-tag-query-string-parameters]]
+=== Query String Parameters
+
+[options="header"]
+|===
+|Name|Description|Required|Schema|Default
+|imageStream|The value metadata.name as defined in the image stream to be used.|
+true|string|
+|imageTag|The value spec.tags.name as defined in the image stream to be used.|
+true|string|
+|namespace|The name of the namespace containing the image stream and image tag
+to use.|false|string|openshift
+|name|Identifies the resources created for this application.|false|string|
+|sourceURI|The git repository URL containing the application source code.|false|
+string|
+|sourceRef|The branch, tag, or commit for the application source code specified
+in sourceURI.|false|string|
+|contextDir|The subdirectory for the application source code specified in
+sourceURI, used as the context directory for the build.|false|string|
+|===
+
+[NOTE]
+====
+link:https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters[Reserved characters] in parameter values should be URL encoded.
+====
+
+[[example-usage-of-an-image-stream-and-image-tag]]
+==== Example
+----
+ create?imageStream=nodejs&imageTag=4&name=nodejs&sourceURI=https%3A%2F%2Fgithub.com%2Fopenshift%2Fnodejs-ex.git&sourceRef=master&contextDir=%2F
+----
+
+[[create-from-url-using-a-template]]
+== Using a Template
+
+[[template-query-string-parameters]]
+=== Query String Parameters
+
+[options="header"]
+|===
+|Name|Description|Required|Schema|Default
+|template|The value of metadata.name as defined in the template to be used.|
+true|string|
+|templateParamsMap|A JSON parameters map containing the template parameter name
+and corresponding value you wish to override.|false|JSON|
+|namespace|The name of the namespace containing the template to use.|false|string|openshift
+|===
+
+[NOTE]
+====
+link:https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters[Reserved characters] in parameter values should be URL encoded.
+====
+
+[[example-usage-of-a-template]]
+==== Example
+----
+ create?template=nodejs-mongodb-example&templateParamsMap={"SOURCE_REPOSITORY_URL"%3A"https%3A%2F%2Fgithub.com%2Fopenshift%2Fnodejs-ex.git"}
+----

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -103,18 +103,16 @@ refreshed (i.e., re-imported) periodically. The period is configured globally at
 system level. See xref:importing-tag-and-image-metadata[Importing Tag and
 Image Metadata] for more details.
 
-[IMPORTANT]
-====
-Avoid tagging {product-title}-managed images (i.e., those built using an {product-title} instance and pushed to its internal registry). There is a
-ifdef::openshift-origin,openshift-enterprise[]
-xref:../install_config/registry/registry_known_issues.adoc#install-config-registry-known-issues[known
-issue]
-endif::[]
-ifdef::openshift-online,openshift-dedicated,atomic-registry[]
-https://docs.openshift.com/enterprise/3.2/release_notes/ose_3_2_release_notes.html#ose-32-known-issues[known issue]
-endif::[]
-that prevents the registry client from pulling from such a tag.
-====
+If you want to instruct docker to always fetch the tagged image from the
+integrated registry, use `--reference-policy=local`. The registry will use
+xref:../install_config/registry/extended_registry_configuration.adoc#middleware-repository-pullthrough[pull-through
+feature] to serve the image to the client and by default, the image blobs will
+be mirrored locally by the registry. As a result, they will be available in
+shorter time next time they are needed. The flag also allows for pulling from
+insecure registries without a need to supply `--insecure-registry` to the
+Docker daemon if the image stream has an xref:insecure-registries[insecure
+annotation] or the tag has an xref:insecure-tag-import-policy[insecure import
+policy].
 
 [[tag-naming]]
 === Tag Naming
@@ -647,19 +645,67 @@ metadata:
 <1> Set the `*openshift.io/image.insecureRepository*` annotation to *true*
 ====
 
+[IMPORTANT]
+====
+This option instructs integrated registry to fall-back to an insecure transport
+for any external image tagged in the image stream when serving it, which is
+dangerous. If possible, avoid this risk by
+xref:insecure-tag-import-policy[marking just an istag as insecure].
+====
+
 ifdef::openshift-enterprise,openshift-origin[]
 [IMPORTANT]
 ====
 The above definition only affects importing tag and image metadata. For this
-image to be used in the cluster (e.g., to be able to do a `docker pull`), each
-node must have Docker configured with the `--insecure-registry` flag. See
+image to be used in the cluster (e.g., to be able to do a `docker pull`) one of
+the following must be true:
+
+1. Each node has Docker configured with the `--insecure-registry` flag matching
+the registry part of the `dockerImageRepository`. See
 xref:../install_config/install/host_preparation.adoc#install-config-install-host-preparation[Host
 Preparation] for information.
+2. Each istag specification must have `referencePolicy.type` set to `Local`. See
+xref:reference-policy[below] for more information.
 ====
 endif::[]
 
-Additionally, you can specify a single tag using an insecure repository. To do
-so, set `*importPolicy.insecure*` in the tag's definition to *true*:
+[[imagestream-tag-policies]]
+==== ImageStream Tag policies
+
+[[insecure-tag-import-policy]]
+===== Insecure Tag Import Policy
+The above annotation applies to all images and tags of a particular
+ImageStream. For a finer-grained control, policies may be set on
+xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[_istags_].
+Set `*importPolicy.insecure*` in the tag's definition to *true* to allow a
+fall-back to insecure transport just for images under this tag.
+
+[NOTE]
+====
+The fall-back to insecure transport for an image under particular _istag_ will
+be enabled either when the image stream is annotated as insecure or the _istag_
+has insecure import policy. The image stream annotation cannot be overriden by
+the `*importPolicy.insecure*` set to *false*. 
+====
+
+[[reference-policy]]
+===== Reference Policy 
+Allows to specify where the image consumers will pull from. It is applicable
+just to remote images (those imported from external registries). There are two
+options to choose from: `*Local*` and `*Source*`. 
+
+The `*Source*` policy intructs clients to pull directly from the source registry of the image. The integrated registry won't be involved unless the image is managed by the cluster (it's not an external image). This is the default policy.
+
+The `*Local*` policy instructs clients to pull always from the integrated
+registry. This is useful if you want to pull from external insecure registries
+without modifying docker daemon settings. The
+xref:../install_config/registry/extended_registry_configuration.adoc#middleware-repository-pullthrough[pull-through
+feature] of the registry will take care of serving the remote image to the
+client. Additionaly, all the blobs will be mirrored for latter faster access.
+
+The policy can be set in a specification of image stream tag as  `referencePolicy.type`.
+
+Here's an example of insecure tag with a local reference policy:
 
 ====
 [source,yaml]
@@ -675,8 +721,13 @@ metadata:
     name: mytag
     importPolicy:
       insecure: true <1>
+    referencePolicy:
+      type: Local <2>
 ----
 <1> Set tag *mytag* to use insecure connection to that registry.
+<2> Set tag *mytag* to use integrated registry for pulling external images. If
+the reference policy type is set to `*Source*`, clients fetch the image
+directly from `my.repo.com:5000/myimage`.
 ====
 
 ifdef::openshift-origin,openshift-online,openshift-enterprise,openshift-dedicated[]

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -100,19 +100,18 @@ $ oc tag --alias=true <source> <destination>
 
 You can also add the `--scheduled=true` flag to have the destination tag be
 refreshed (i.e., re-imported) periodically. The period is configured globally at
-system level. See xref:importing-tag-and-image-metadata[Importing Tag and
-Image Metadata] for more details.
+system level. See xref:importing-tag-and-image-metadata[Importing Tag and Image
+Metadata] for more details.
 
-If you want to instruct docker to always fetch the tagged image from the
-integrated registry, use `--reference-policy=local`. The registry will use
+If you want to instruct Docker to always fetch the tagged image from the
+integrated registry, use `--reference-policy=local`. The registry uses the
 xref:../install_config/registry/extended_registry_configuration.adoc#middleware-repository-pullthrough[pull-through
-feature] to serve the image to the client and by default, the image blobs will
-be mirrored locally by the registry. As a result, they will be available in
-shorter time next time they are needed. The flag also allows for pulling from
-insecure registries without a need to supply `--insecure-registry` to the
-Docker daemon if the image stream has an xref:insecure-registries[insecure
-annotation] or the tag has an xref:insecure-tag-import-policy[insecure import
-policy].
+feature] to serve the image to the client. By default, the image blobs are
+mirrored locally by the registry. As a result, they are available for a  shorter
+time the next time they are needed. The flag also allows for pulling from
+insecure registries without a need to supply `--insecure-registry` to the Docker
+daemon if the image stream has an xref:insecure-registries[insecure annotation]
+or the tag has an xref:insecure-tag-import-policy[insecure import policy].
 
 [[tag-naming]]
 === Tag Naming
@@ -142,6 +141,7 @@ Although tag naming convention is up to you, here are a few examples:
 If you require dates in tag names, periodically inspect old and unsupported
 images and _istags_ and remove them. Otherwise, you might experience increasing
 resource usage caused by old images.
+
 [[tag-removal]]
 === Removing Tags from Image Streams
 To remove a tag completely from an image stream run:
@@ -647,66 +647,70 @@ metadata:
 
 [IMPORTANT]
 ====
-This option instructs integrated registry to fall-back to an insecure transport
+This option instructs integrated registry to fall back to an insecure transport
 for any external image tagged in the image stream when serving it, which is
 dangerous. If possible, avoid this risk by
-xref:insecure-tag-import-policy[marking just an istag as insecure].
+xref:insecure-tag-import-policy[marking just an `istag` as insecure].
 ====
 
 ifdef::openshift-enterprise,openshift-origin[]
 [IMPORTANT]
 ====
 The above definition only affects importing tag and image metadata. For this
-image to be used in the cluster (e.g., to be able to do a `docker pull`) one of
+image to be used in the cluster (e.g., to be able to do a `docker pull`), one of
 the following must be true:
 
-1. Each node has Docker configured with the `--insecure-registry` flag matching
-the registry part of the `dockerImageRepository`. See
+. Each node has Docker configured with the `--insecure-registry` flag matching the
+registry part of the `dockerImageRepository`. See
 xref:../install_config/install/host_preparation.adoc#install-config-install-host-preparation[Host
-Preparation] for information.
-2. Each istag specification must have `referencePolicy.type` set to `Local`. See
-xref:reference-policy[below] for more information.
+Preparation] for more information.
+
+. Each `istag` specification must have `referencePolicy.type` set to `Local`. See
+xref:reference-policy[Reference Policy] for more information.
 ====
 endif::[]
 
 [[imagestream-tag-policies]]
-==== ImageStream Tag policies
+==== ImageStream Tag Policies
 
 [[insecure-tag-import-policy]]
 ===== Insecure Tag Import Policy
 The above annotation applies to all images and tags of a particular
-ImageStream. For a finer-grained control, policies may be set on
-xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[_istags_].
-Set `*importPolicy.insecure*` in the tag's definition to *true* to allow a
+`ImageStream`. For a finer-grained control, policies may be set on
+xref:../architecture/core_concepts/builds_and_image_streams.adoc#image-stream-tag[`istags`].
+Set `importPolicy.insecure` in the tag's definition to `true` to allow a
 fall-back to insecure transport just for images under this tag.
 
 [NOTE]
 ====
-The fall-back to insecure transport for an image under particular _istag_ will
-be enabled either when the image stream is annotated as insecure or the _istag_
-has insecure import policy. The image stream annotation cannot be overriden by
-the `*importPolicy.insecure*` set to *false*. 
+The fall-back to insecure transport for an image under particular `istag` will
+be enabled either when the image stream is annotated as insecure or the `istag`
+has insecure import policy. The `importPolicy.insecure`` set to `false` can not
+override the image stream annotation.
 ====
 
 [[reference-policy]]
-===== Reference Policy 
-Allows to specify where the image consumers will pull from. It is applicable
-just to remote images (those imported from external registries). There are two
-options to choose from: `*Local*` and `*Source*`. 
+===== Reference Policy
+The Reference Policy allows you to specify where the image consumers will pull
+from. It is only applicable to remote images (those imported from external
+registries). There are two options to choose from, `Local` and `Source`.
 
-The `*Source*` policy intructs clients to pull directly from the source registry of the image. The integrated registry won't be involved unless the image is managed by the cluster (it's not an external image). This is the default policy.
+The `Source` policy instructs clients to pull directly from the source registry
+of the image. The integrated registry is not involved unless the image is
+managed by the cluster. (It is not an external image.) This is the default
+policy.
 
-The `*Local*` policy instructs clients to pull always from the integrated
+The `Local` policy instructs clients to always pull from the integrated
 registry. This is useful if you want to pull from external insecure registries
-without modifying docker daemon settings. The
+without modifying Docker daemon settings. The
 xref:../install_config/registry/extended_registry_configuration.adoc#middleware-repository-pullthrough[pull-through
-feature] of the registry will take care of serving the remote image to the
-client. Additionaly, all the blobs will be mirrored for latter faster access.
+feature] of the registry serves the remote image to the client. Additionally,
+all the blobs are mirrored for faster access later.
 
-The policy can be set in a specification of image stream tag as  `referencePolicy.type`.
+You can set the policy in a specification of image stream tag as
+`referencePolicy.type`.
 
-Here's an example of insecure tag with a local reference policy:
-
+.Exmple of Insecure Tag with a Local Reference Policy
 ====
 [source,yaml]
 ----
@@ -724,9 +728,9 @@ metadata:
     referencePolicy:
       type: Local <2>
 ----
-<1> Set tag *mytag* to use insecure connection to that registry.
-<2> Set tag *mytag* to use integrated registry for pulling external images. If
-the reference policy type is set to `*Source*`, clients fetch the image
+<1> Set tag `mytag` to use an insecure connection to that registry.
+<2> Set tag `mytag` to use integrated registry for pulling external images. If
+the reference policy type is set to `Source`, clients fetch the image
 directly from `my.repo.com:5000/myimage`.
 ====
 

--- a/dev_guide/secrets.adoc
+++ b/dev_guide/secrets.adoc
@@ -203,10 +203,8 @@ Secret keys must be in a DNS subdomain.
 [[secrets-examples]]
 == Examples
 
-.YAML of a Secret that will create four files
-Files *username* and *password* will contain decoded values.  File *hostname* will contain the provided string.  File *secret.properties* will contain the provided data.
+.YAML Secret That Will Create Four Files
 ====
-
 [source,yaml]
 ----
 apiVersion: v1
@@ -214,14 +212,18 @@ kind: Secret
 metadata:
   name: test-secret
 data:
-  username: dmFsdWUtMQ0K
-  password: dmFsdWUtMQ0KDQo=
+  username: dmFsdWUtMQ0K     <1>
+  password: dmFsdWUtMQ0KDQo= <2>
 stringData:
-  hostname: myapp.mydomain.com
-  secret.properties: |-
+  hostname: myapp.mydomain.com <3>
+  secret.properties: |-     <4>
     property1=valueA
     property2=valueB
 ----
+<1> File contains decoded values.
+<2> File contains decoded values.
+<3> File contains the provided string.
+<4> File contains the provided data.
 ====
 
 .YAML of a Pod Populating Files in a Volume with Secret Data

--- a/dev_guide/secrets.adoc
+++ b/dev_guide/secrets.adoc
@@ -202,6 +202,27 @@ Secret keys must be in a DNS subdomain.
 [[secrets-examples]]
 == Examples
 
+.YAML of a Secret that will create four files
+Files *username* and *password* will contain decoded values.  File *hostname* will contain the provided string.  File *secret.properties* will contain the provided data.
+====
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+data:
+  username: dmFsdWUtMQ0K
+  password: dmFsdWUtMQ0KDQo=
+stringData:
+  hostname: myapp.mydomain.com
+  secret.properties: |-
+    property1=valueA
+    property2=valueB
+----
+====
+
 .YAML of a Pod Populating Files in a Volume with Secret Data
 ====
 

--- a/dev_guide/templates.adoc
+++ b/dev_guide/templates.adoc
@@ -370,20 +370,24 @@ deploying. It should also provide links to additional information, such as a
 that will include it into one of the provided catalog categories. Refer to the
 `id` and `categoryAliases` in `CATALOG_CATEGORIES` in the console's
 link:https://github.com/openshift/origin-web-console/blob/master/app/scripts/constants.js[constants
-file]. The categories can also be
+file].
+ifdef::openshift-enterprise,openshift-origin[]
+The categories can also be
 xref:../install_config/web_console_customization.adoc#configuring-catalog-categories[customized]
 for the whole cluster.
+endif::[]
 <5> An icon to be displayed with your template in the web console. Choose from our
 existing
-link:https://rawgit.com/openshift/origin-web-console/master/app/styles/fonts/openshift-logos-icon/demo.html[logo
-icons] when possible. You can also use icons from
+link:https://rawgit.com/openshift/origin-web-console/master/app/styles/fonts/openshift-logos-icon/demo.html[logo icons] when possible. You can also use icons from
 link:http://fontawesome.io/icons/[FontAwesome] and
-link:https://www.patternfly.org/styles/icons/[Patternfly]. Alternatively,
-provide icons through
+link:https://www.patternfly.org/styles/icons/[Patternfly].
+ifdef::openshift-enterprise,openshift-origin[]
+Alternatively, provide icons through
 xref:../install_config/web_console_customization.adoc#loading-custom-scripts-and-stylesheets[CSS
 customizations] that can be added to an {product-title} cluster that uses your
 template. You must specify an icon class that exists, or it will prevent falling
 back to the generic icon.
+endif::[]
 <6> An instructional message that is displayed when this template is instantiated.
 This field should inform the user how to use the newly created resources.
 Parameter substitution is performed on the message before being displayed so

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -3,7 +3,7 @@
 {product-author}
 {product-version}
 ifdef::openshift-enterprise[]
-:latest-tag: v3.4.1
+:latest-tag: 3.4.1
 endif::[]
 ifdef::openshift-origin[]
 :latest-tag: v1.4.1

--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -570,6 +570,10 @@ information can be found under the
 link:https://github.com/hawkular/hawkular-openshift-agent[Hawkular OpenShift
 Agent documentation].
 
+The agent runs as a daemon set in your cluster and is deployed to the `default`
+project. By deploying to the `default` project, the agent continues to monitor
+all your pods even if the `ovs_multitenant` plug-in is enabled.
+
 To deploy the agent, you will need to gather two configuration files:
 ifdef::openshift-origin[]
 ----
@@ -586,9 +590,9 @@ endif::[]
 
 To set up and deploy the agent into your {product-title} cluster, run:
 ----
-$ oc create -f hawkular-openshift-agent-configmap.yaml -n openshift-infra
-$ oc process -f hawkular-openshift-agent.yaml | oc create -n openshift-infra -f -
-$ oc adm policy add-cluster-role-to-user hawkular-openshift-agent system:serviceaccount:openshift-infra:hawkular-openshift-agent
+$ oc create -f hawkular-openshift-agent-configmap.yaml -n default
+$ oc process -f hawkular-openshift-agent.yaml | oc create -n default -f -
+$ oc adm policy add-cluster-role-to-user hawkular-openshift-agent system:serviceaccount:default:hawkular-openshift-agent
 ----
 
 [[Undeploying-the-hawkular-openshift-agent]]
@@ -596,7 +600,7 @@ $ oc adm policy add-cluster-role-to-user hawkular-openshift-agent system:service
 
 To undeploy the Hawkular Metrics Agent, run:
 ----
-$ oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles --selector=metrics-infra=agent -n openshift-infra
+$ oc delete all,secrets,sa,templates,configmaps,daemonsets,clusterroles --selector=metrics-infra=agent -n default
 ----
 
 [[install-setting-the-metrics-public-url]]

--- a/install_config/install/disconnected_install.adoc
+++ b/install_config/install/disconnected_install.adoc
@@ -4,6 +4,7 @@
 {product-version}
 :latest-tag: v3.4.1.5
 :latest-int-tag: 3.4.1
+:latest-registry-console-tag: 3.4
 :data-uri:
 :icons:
 :experimental:
@@ -233,6 +234,15 @@ registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift:lates
 registry.access.redhat.com/jboss-webserver-3/webserver30-tomcat7-openshift:1.1
 ----
 
+. If you are using a stand-alone registry or plan to enable the registry console
+with the integrated registry, you must pull the *registry-console* image.
++
+Replace `<tag>` with `{latest-registry-console-tag}` for the latest version.
++
+----
+# docker pull registry.access.redhat.com/openshift3/registry-console:<tag>
+----
+
 [[disconnected-preparing-images-for-export]]
 === Preparing Images for Export
 
@@ -425,6 +435,12 @@ xref:../../install_config/install/advanced_install.adoc#install-config-install-a
 
 You now need to xref:../../install_config/registry/index.adoc#install-config-registry-overview[create
 the internal Docker registry].
+
+If you want to
+xref:../../install_config/install/stand_alone_registry.adoc#install-config-installing-stand-alone-registry[install
+a stand-alone registry], you must xref:disconnected-syncing-images[pull the
+*registry-console* container image] and set `deployment_subtype=registry` in the
+inventory file.
 
 [[disconnected-post-installation-changes]]
 == Post-Installation Changes

--- a/install_config/install/prerequisites.adoc
+++ b/install_config/install/prerequisites.adoc
@@ -747,7 +747,7 @@ a|The user is installing in a VPC that is not configured for both `*DNS hostname
 |`*ip*`
 a|Possibly if they have multiple network interfaces configured and they want to
 use one other than the default. You must first set
-`*openshift_node_set_node_ip*` to `True`. Otherwise, the SDN would attempt to
+`*openshift_set_node_ip*` to `True`. Otherwise, the SDN would attempt to
 use the `*hostname*` setting or try to resolve the host name for the IP.
 
 |`*public_hostname*`

--- a/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
+++ b/install_config/persistent_storage/dynamically_provisioning_pvs.adoc
@@ -301,8 +301,8 @@ parameters:
 <3> Secret Name for `adminId`. It is required. The provided secret must have type "kubernetes.io/rbd".
 <4> The namespace for `adminSecret`. Default is "default".
 <5> Ceph RBD pool. Default is "rbd".
-<6> Ceph client ID that is used to map the RBD image. Default is the same as `adminId`.
-<7> The name of Ceph Secret for `userId` to map RBD image. It must exist in the same namespace as PVCs. It is required.
+<6> Ceph client ID that is used to map the Ceph RBD image. Default is the same as `adminId`.
+<7> The name of Ceph Secret for `userId` to map Ceph RBD image. It must exist in the same namespace as PVCs. It is required.
 ====
 
 

--- a/install_config/persistent_storage/persistent_storage_glusterfs.adoc
+++ b/install_config/persistent_storage/persistent_storage_glusterfs.adoc
@@ -51,16 +51,22 @@ storage served out from the storage clusters through common storage protocols.
 .Architecture - Dedicated Red Hat Gluster Storage Cluster Using the {product-title} Volume Plug-in
 image::OpenShift_Containerization_Gluster_412816_0716_JCS_dedicated.png["Architecture - Dedicated Red Hat Gluster Storage Cluster Using the {product-title} Volume Plug-in"]
 
+You can also dynamically provision volumes in a dedicated Red Hat Gluster
+Storage cluster that are enabled by Heketi. See
+link:https://access.redhat.com/documentation/en-US/Red_Hat_Storage/3.1/html/Administration_Guide/ch06s02.html[Managing Volumes Using Heketi] in the Red Hat Gluster Storage Administration Guide for
+more information.
+
 This solution is a conventional deployment where containerized compute
 applications run on an {product-title} cluster. The remaining sections in this
 topic provide the step-by-step instructions for the dedicated Red Hat Gluster
 Storage solution.
 
-This topic presumes some familiarity with {product-title} and GlusterFS; see the
-link:https://access.redhat.com/documentation/en-US/Red_Hat_Storage/3/html/Administration_Guide/index.html[Red
-Hat Gluster Storage 3 Administration Guide] for more on GlusterFS. See the
-xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[Persistent
-Storage] topic for details on the {product-title} PV framework in general.
+This topic presumes some familiarity with {product-title} and GlusterFS:
+
+- See the
+xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[Persistent Storage] topic for details on the {product-title} PV framework in general.
+- See the
+link:https://access.redhat.com/documentation/en-US/Red_Hat_Storage/3/html/Administration_Guide/index.html[Red Hat Gluster Storage 3 Administration Guide] for more on GlusterFS.
 
 [IMPORTANT]
 ====
@@ -112,7 +118,7 @@ xref:gfs-supported-operating-systems[Supported Operating Systems].
 Gluster Storage server node. Ensure that correct DNS records exist, and that the
 FQDN is resolvable via both forward and reverse DNS lookup.
 
-.Red Hat OpenShift Enterprise
+.Red Hat {product-title}
 - All installations of {product-title} must have valid subscriptions to Red Hat
 Network channels and Subscription Management repositories.
 - {product-title} installations must adhere to the requirements laid out in the
@@ -130,7 +136,9 @@ Client] in the Red Hat Gluster Storage Administration Guide.
 [[gfs-provisioning]]
 == Provisioning
 
-To provision GlusterFS volumes the following are required:
+To provision GlusterFS volumes using the
+xref:gfs-dedicated-storage-cluster[dedicated storage cluster solution], the
+following are required:
 
 - An existing storage device in your underlying infrastructure.
 - A distinct list of servers (IP addresses) in the Gluster cluster, to be defined as endpoints.

--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -90,7 +90,7 @@ playbooks, using different sets of configuration for the
 `openshift_certificate_expiry` role.
 
 Just like the
-xref:install-config-running-the-certificate-redeploy-playbook[redeploying s/certificates playbook], these playbooks must be used with an inventory that is
+xref:install-config-running-the-certificate-redeploy-playbook[redeploying certificates playbook], these playbooks must be used with an inventory that is
 representative of the cluster. For best results, run `ansible-playbook` with the
 `-v` option.
 

--- a/install_config/registry/deploy_registry_existing_clusters.adoc
+++ b/install_config/registry/deploy_registry_existing_clusters.adoc
@@ -183,8 +183,8 @@ storage:
   delete:
     enabled: true
   s3:
-    accesskey: awsaccesskey
-    secretkey: awssecretkey
+    accesskey: awsaccesskey <1>
+    secretkey: awssecretkey <2>
     region: us-west-1
     regionendpoint: http://myobjects.local
     bucket: bucketname
@@ -195,6 +195,8 @@ storage:
     chunksize: 5242880
     rootdirectory: /s3/object/name/prefix
 ----
+<1> Replace with your Amazon access key.
+<2> Replace with your Amazon secret key.
 ====
 
 All of the *s3* configuration options are documented in upstream's

--- a/install_config/registry/registry_known_issues.adoc
+++ b/install_config/registry/registry_known_issues.adoc
@@ -59,6 +59,12 @@ Settings] in the
 xref:../../install_config/persistent_storage/persistent_storage_nfs.adoc#install-config-persistent-storage-persistent-storage-nfs[Persistent
 Storage Using NFS] topic for details.
 
+[NOTE]
+====
+The guidelines for NFS are recommended to help you get started. You
+may switch off from NFS when moving to production.
+====
+
 == Pull of Internally Managed Image Fails with "not found" Error
 
 This error occurs when the pulled image is pushed to an image stream different

--- a/install_config/router/f5_router.adoc
+++ b/install_config/router/f5_router.adoc
@@ -109,6 +109,7 @@ $ oadm router \
     --external-host-http-vserver=ose-vserver \
     --external-host-https-vserver=https-ose-vserver \
     --external-host-private-key=/path/to/key \
+    --host-network=false \
     --service-account=router
 ----
 ====
@@ -124,6 +125,7 @@ $ oadm router \
     --external-host-http-vserver=ose-vserver \
     --external-host-https-vserver=https-ose-vserver \
     --external-host-private-key=/path/to/key \
+    --host-network=false \
     --service-account=router
 ----
 ====
@@ -253,6 +255,7 @@ $ oadm router \
     --external-host-private-key=/path/to/key \
     --credentials='/etc/openshift/master/openshift-router.kubeconfig' \
     --service-account=router \
+    --host-network=false \
     --external-host-internal-ip=10.3.89.213 \
     --external-host-vxlan-gw=10.131.0.5/14
 ----

--- a/install_config/storage_examples/dedicated_gluster_dynamic_example.adoc
+++ b/install_config/storage_examples/dedicated_gluster_dynamic_example.adoc
@@ -1,0 +1,408 @@
+[[install-config-storage-examples-dedicated-gluster-dynamic-example]]
+= Complete Example of Dynamic Provisioning Using Dedicated GlusterFS
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+[[dedicated-glusterfs-dynamic-example-overview]]
+== Overview
+
+[NOTE]
+====
+This example assumes a functioning {product-title} cluster along with Heketi and
+GlusterFS. All `oc` commands are executed on the {product-title} master host.
+====
+
+xref:gluster_dynamic_example.adoc#install-config-storage-examples-gluster-dynamic-example[Container Native Storage (CNS) using GlusterFS and Heketi] is a great way to perform dynamic
+provisioning for shared filesystems in a Kubernetes-based cluster like
+{product-title}. However, if an existing,
+xref:../../install_config/persistent_storage/persistent_storage_glusterfs.adoc#gfs-dedicated-storage-cluster[dedicated Gluster cluster] is available external to the {product-title} cluster, you can
+also provision storage from it rather than a containerized GlusterFS
+implementation.
+
+This example:
+
+- Shows how simple it is to install and configure a Heketi server to
+work with {product-title} to perform dynamic provisioning.
+
+- Assumes some familiarity with Kubernetes and the
+link:http://kubernetes.io/docs/user-guide/persistent-volumes/[Kubernetes Persistent Storage] model.
+
+- Assumes you have access to an existing, dedicated GlusterFS cluster that has raw
+devices available for consumption and management by a Heketi server. If you do
+not have this, you can create a three node cluster using your virtual machine
+solution of choice. Ensure sure you create a few raw devices and give plenty of
+space (at least 100GB recommended). See
+link:https://access.redhat.com/documentation/en-US/Red_Hat_Storage/3.1/html/Installation_Guide/[Red Hat Gluster Storage Installation Guide].
+
+[[dedicated-glusterfs-dynamic-example-enviornment]]
+== Environment and Prerequisites
+
+This example uses the following environment and prerequisites:
+
+* GlusterFS cluster running Red Hat Gluster Storage (RHGS) 3.1. Three nodes, each with at least two 100GB RAW devices:
+** *gluster23.rhs* (192.168.1.200)
+** *gluster24.rhs* (192.168.1.201)
+** *gluster25.rhs* (192.168.1.202)
+
+* Heketi service/client node running Red Hat Enterprise Linux (RHEL) 7.x or RHGS 3.1. Heketi can be installed on one of the Gluster nodes:
+** *glusterclient2.rhs* (192.168.1.203)
+
+* {product-title} node. This example uses an all-in-one {product-title} cluster
+(master and node on a single host), though it can work using a standard,
+multi-node cluster as well.
+** *k8dev2.rhs* (192.168.1.208)
+
+[[dedicated-glusterfs-dynamic-example-install-heketi]]
+== Installing and Configuring Heketi
+
+Heketi is used to manage the Gluster cluster storage (adding volumes, removing
+volumes, etc.). As stated, this can be RHEL or RHGS, and can be installed on one
+of the existing Gluster storage nodes. This example uses a stand-alone RHGS 3.1
+node running Heketi.
+
+The
+link:https://access.redhat.com/documentation/en-US/Red_Hat_Storage/3.1/html/Administration_Guide/ch06s02.html[Red Hat Gluster Storage Administration Guide] can be used a reference during this process.
+
+. Install Heketi and the Heketi client. From the host designated to run Heketi and
+the Heketi client, run:
++
+----
+# yum install heketi heketi-client -y
+----
++
+[NOTE]
+====
+The Heketi server can be any of the existing hosts, though typically this will
+be the {product-title} master host. This example, however, uses a separate host
+not part of the GlusterFS or {product-title} cluster.
+====
+
+. Create and install Heketi private keys on each GlusterFS cluster node. From the
+host that is running Heketi:
++
+----
+# ssh-keygen -f /etc/heketi/heketi_key -t rsa -N ''
+# ssh-copy-id -i /etc/heketi/heketi_key.pub root@gluster23.rhs
+# ssh-copy-id -i /etc/heketi/heketi_key.pub root@gluster24.rhs
+# ssh-copy-id -i /etc/heketi/heketi_key.pub root@gluster25.rhs
+# chown heketi:heketi /etc/heketi/heketi_key*
+----
+
+. Edit the *_/usr/share/heketi/heketi.json_* file to setup the SSH executor. Below
+is an excerpt from the *_/usr/share/heketi/heketi.json file_*; the parts to
+configure are the `executor` and SSH sections:
++
+[source,json]
+----
+	"executor": "ssh", <1>
+
+	"_sshexec_comment": "SSH username and private key file information",
+	"sshexec": {
+  	  "keyfile": "/etc/heketi/heketi_key", <2>
+  	  "user": "root", <3>
+  	  "port": "22", <4>
+  	  "fstab": "/etc/fstab" <5>
+	},
+----
+<1> Change `executor` from `mock` to `ssh`.
+<2> Add in the public key directory specified in previous step.
+<3> Update `user` to a user that has `sudo` or root access.
+<4> Set `port` to `22` and remove all other text.
+<5> Set `fstab` to the default, `/etc/fstab` and remove all other text.
+
+. Restart and enable service:
++
+----
+# systemctl restart heketi
+# systemctl enable heketi
+----
+
+. Test the connection to Heketi:
++
+----
+# curl http://glusterclient2.rhs:8080/hello
+Hello from Heketi
+----
+
+. Set an environment variable for the Heketi server:
++
+----
+# export HEKETI_CLI_SERVER=http://glusterclient2.rhs:8080
+----
+
+[[dedicated-glusterfs-dynamic-example-loading-topology]]
+== Loading Topology
+
+Topology is used to tell Heketi about the environment and what nodes and devices
+it will manage.
+
+[NOTE]
+====
+Heketi is currently limited to managing raw devices only. If a device is already
+a Gluster volume, it will be skipped and ignored.
+====
+
+. Create and load the topology file. There is a sample file located in
+*_/usr/share/heketi/toplogy-sample.json_* by default, or *_/etc/heketi_*
+depending on how it was installed.
++
+[source,json]
+----
+{
+  "clusters": [
+    {
+      "nodes": [
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "gluster23.rhs"
+              ],
+              "storage": [
+                "192.168.1.200"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/sde",
+            "/dev/sdf"
+          ]
+        },
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "gluster24.rhs"
+              ],
+              "storage": [
+                "192.168.1.201"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/sde",
+            "/dev/sdf"
+          ]
+        },
+        {
+          "node": {
+            "hostnames": {
+              "manage": [
+                "gluster25.rhs"
+              ],
+              "storage": [
+                "192.168.1.202"
+              ]
+            },
+            "zone": 1
+          },
+          "devices": [
+            "/dev/sde",
+            "/dev/sdf"
+          ]
+        },
+      ]
+    }
+  ]
+}
+----
+
+. Using `heketi-cli`, run the following command to load the topology of your
+environment.
++
+----
+# heketi-cli topology load --json=topology.json
+
+    	Found node gluster23.rhs on cluster bdf9d8ca3fa269ff89854faf58f34b9a
+   		Adding device /dev/sde ... OK
+   	 	Adding device /dev/sdf ... OK
+    	Creating node gluster24.rhs ... ID: 8e677d8bebe13a3f6846e78a67f07f30
+   	 	Adding device /dev/sde ... OK
+   	 	Adding device /dev/sdf ... OK
+...
+...
+----
+
+. Create a Gluster volume to verify Heketi:
++
+----
+# heketi-cli volume create --size=50
+----
+
+. View the volume information from one of the the Gluster nodes:
++
+----
+# gluster volume info
+
+	Volume Name: vol_335d247ac57ecdf40ac616514cc6257f <1>
+	Type: Distributed-Replicate
+	Volume ID: 75be7940-9b09-4e7f-bfb0-a7eb24b411e3
+	Status: Started
+...
+...
+----
+<1> Volume created by `heketi-cli`.
+
+[[dedicated-glusterfs-dynamic-example-provision-volume]]
+== Dynamically Provision a Volume
+
+. Create a `StorageClass` object definition. The definition below is based on the
+minimum requirements needed for this example to work with {product-title}. See
+xref:../../install_config/persistent_storage/dynamically_provisioning_pvs.adoc#install-config-persistent-storage-dynamically-provisioning-pvs[Dynamic
+Provisioning and Creating Storage Classes] for additional parameters and
+specification definitions.
++
+[source,yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: gluster-dyn
+provisioner: kubernetes.io/glusterfs
+parameters:
+  resturl: "http://glusterclient2.rhs:8080" <1>
+  restauthenabled: "false" <2>
+----
+<1> The Heketi server from the `HEKETI_CLI_SERVER` environment variable.
+<2> Since authentication is not turned on in this example, set to `false`.
+
+. From the {product-title} master host, create the storage class:
++
+----
+# oc create -f glusterfs-storageclass1.yaml
+storageclass "gluster-dyn" created
+----
+
+. Create a persistent volume claim (PVC), requesting the newly-created storage
+class. For example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+ name: gluster-dyn-pvc
+ annotations:
+   volume.beta.kubernetes.io/storage-class: gluster-dyn
+spec:
+ accessModes:
+  - ReadWriteMany
+ resources:
+   requests:
+        storage: 30Gi
+----
+
+. From the {product-title} master host, create the PVC:
++
+----
+# oc create -f glusterfs-pvc-storageclass.yaml
+persistentvolumeclaim "gluster-dyn-pvc" created
+----
+
+. View the PVC to see that the volume was dynamically created and bound to the PVC:
++
+----
+# oc get pvc
+NAME          	STATUS	VOLUME                                 		CAPACITY   	ACCESSMODES   	STORAGECLASS   	AGE
+gluster-dyn-pvc Bound	pvc-78852230-d8e2-11e6-a3fa-0800279cf26f   	30Gi   		RWX       	gluster-dyn	42s
+----
+
+. Verify and view the new volume on one of the Gluster nodes:
++
+----
+# gluster volume info
+
+	Volume Name: vol_335d247ac57ecdf40ac616514cc6257f <1>
+	Type: Distributed-Replicate
+	Volume ID: 75be7940-9b09-4e7f-bfb0-a7eb24b411e3
+	Status: Started
+        ...
+	Volume Name: vol_f1404b619e6be6ef673e2b29d58633be <2>
+	Type: Distributed-Replicate
+	Volume ID: 7dc234d0-462f-4c6c-add3-fb9bc7e8da5e
+	Status: Started
+	Number of Bricks: 2 x 2 = 4
+	...
+----
+<1> Volume created by `heketi-cli`.
+<2> New dynamically created volume triggered by Kubernetes and the storage class.
+
+[[dedicated-glusterfs-dynamic-example-nginx]]
+== Creating a NGINX Pod That Uses the PVC
+
+At this point, you have a dynamically created GlusterFS volume bound to a PVC.
+You can now now utilize this PVC in a pod. In this example, create a simple
+NGINX pod.
+
+. Create the pod object definition:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gluster-pod1
+  labels:
+    name: gluster-pod1
+spec:
+  containers:
+  - name: gluster-pod1
+    image: gcr.io/google_containers/nginx-slim:0.8
+    ports:
+    - name: web
+      containerPort: 80
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: gluster-vol1
+      mountPath: /usr/share/nginx/html
+  volumes:
+  - name: gluster-vol1
+    persistentVolumeClaim:
+      claimName: gluster-dyn-pvc <1>
+----
+<1> The name of the PVC created in the previous step.
+
+. From the {product-title} master host, create the pod:
++
+----
+# oc create -f nginx-pod.yaml
+pod "gluster-pod1" created
+----
+
+. View the pod. Give it a few minutes, as it might need to download the image if
+it does not already exist:
++
+----
+# oc get pods -o wide
+NAME                               READY     STATUS    RESTARTS   AGE       IP               NODE
+gluster-pod1                       1/1       Running   0          9m        10.38.0.0        node1
+----
+
+. Now remote into the container with `oc exec` and create an *_index.html_* file:
++
+----
+# oc exec -ti gluster-pod1 /bin/sh
+$ cd /usr/share/nginx/html
+$ echo 'Hello World from GlusterFS!!!' > index.html
+$ ls
+index.html
+$ exit
+----
+
+. Now `curl` the URL of the pod:
++
+----
+# curl http://10.38.0.0
+Hello World from GlusterFS!!!
+----

--- a/install_config/storage_examples/gluster_dynamic_example.adoc
+++ b/install_config/storage_examples/gluster_dynamic_example.adoc
@@ -1,5 +1,5 @@
 [[install-config-storage-examples-gluster-dynamic-example]]
-= Complete Example of Dynamic Provisioning Using GlusterFS
+= Complete Example of Dynamic Provisioning Using Containerized GlusterFS
 {product-author}
 {product-version}
 :data-uri:
@@ -11,16 +11,14 @@
 
 toc::[]
 
+[[cns-glusterfs-dynamic-example-overview]]
+== Overview
 
 [NOTE]
 ====
-This example assumes a working {product-title} installed and functioning along
-with Heketi and GlusterFS.
-
-All `oc` commands are executed on the {product-title} master host.
+This example assumes a functioning {product-title} cluster along with Heketi and
+GlusterFS. All `oc` commands are executed on the {product-title} master host.
 ====
-
-== Overview
 
 This topic provides an end-to-end example of how to dynamically provision
 GlusterFS volumes. In this example, a simple NGINX HelloWorld application is

--- a/install_config/upgrading/manual_upgrades.adoc
+++ b/install_config/upgrading/manual_upgrades.adoc
@@ -857,39 +857,6 @@ Hat Enterprise Linux 7 system where you can run the CLI as a user with
 The *openshift-ansible-roles* package provides the latest example JSON files.
 endif::[]
 
-. Update the global *openshift* project by running the following commands.
-Receiving warnings about items that already exist is expected.
-+
-ifdef::openshift-enterprise[]
-====
-----
-# oc create -n openshift -f /usr/share/openshift/examples/image-streams/image-streams-rhel7.json
-# oc create -n openshift -f /usr/share/openshift/examples/image-streams/dotnet_imagestreams.json
-# oc create -n openshift -f /usr/share/openshift/examples/db-templates
-# oc create -n openshift -f /usr/share/openshift/examples/quickstart-templates
-# oc create -n openshift -f /usr/share/openshift/examples/xpaas-streams
-# oc create -n openshift -f /usr/share/openshift/examples/xpaas-templates
-# oc replace -n openshift -f /usr/share/openshift/examples/image-streams/image-streams-rhel7.json
-# oc replace -n openshift -f /usr/share/openshift/examples/db-templates
-# oc replace -n openshift -f /usr/share/openshift/examples/quickstart-templates
-# oc replace -n openshift -f /usr/share/openshift/examples/xpaas-streams
-# oc replace -n openshift -f /usr/share/openshift/examples/xpaas-templates
-----
-====
-endif::[]
-ifdef::openshift-origin[]
-====
-----
-# oc create -n openshift -f roles/openshift_examples/files/examples/v1.1/image-streams/image-streams-centos7.json
-# oc create -n openshift -f roles/openshift_examples/files/examples/v1.1/db-templates
-# oc create -n openshift -f roles/openshift_examples/files/examples/v1.1/quickstart-templates
-# oc replace -n openshift -f roles/openshift_examples/files/examples/v1.1/image-streams/image-streams-centos7.json
-# oc replace -n openshift -f roles/openshift_examples/files/examples/v1.1/db-templates
-# oc replace -n openshift -f roles/openshift_examples/files/examples/v1.1/quickstart-templates
-----
-====
-endif::[]
-
 . After a manual upgrade, get the latest templates from
 *openshift-ansible-roles*:
 +

--- a/install_config/upgrading/os_upgrades.adoc
+++ b/install_config/upgrading/os_upgrades.adoc
@@ -7,26 +7,54 @@
 :experimental:
 :prewrap!:
 
-[[upgrading-os-upgrades-impacts]]
-== Impacts
+== Updating and Upgrading the Operating System
 
-When updating or upgrading your operating system (OS), either changing OS
-versions or updating the system software, be aware that this can impact the
-{product-title} software running on those machines. In particular, these updates
-can affect the `iptables` rules or `ovs` flows that {product-title} requires to
-operate.
+Updating or upgrading your operating system (OS), by either changing OS versions
+or updating the system software, can impact the {product-title} software running
+on those machines. In particular, these updates can affect the `iptables` rules
+or `ovs` flows that {product-title} requires to operate.
 
-[[upgrading-os-upgrades-solutions]]
-== Solutions
+Use the following to safely upgrade the OS on a host:
 
-Reboot the node to ensure that all of the software is running the new
-versions, especially if a new kernel is installed. A reboot will also ensure
-that the `docker` and {product-title} processes have been restarted, which will
-force them to check that all of the rules in other services are correct.
+. Ensure the host is unschedulable, meaning that no new pods will be placed onto the host:
++
+----
+$ oadm manage-node <node_name> --schedulable=false
+----
 
-However, if you do not wish to do a reboot of the node, then it is possible to
-just restart the services that are affected, or to preserve the `iptables`
-state. Both processes are described in the
+. Migrate the pods from the host:
++
+----
+$ oadm drain <node_name> --force --delete-local-data --ignore-daemonsets
+----
+
+. Install or update the **-excluder* packages on each host with the following.
+This ensures the hosts stay on the correct versions of {product-title}, as per
+the *atomic-openshift* and *docker* packages, instead of the most current
+versions:
++
+----
+# yum install atomic-openshift-excluder atomic-openshift-docker-excluder
+----
++
+This adds entries to the `exclude` directive in the host's *_/etc/yum.conf_*
+file.
+
+. Update or upgrade the host packages, and reboot the host. A reboot ensures
+that the host is running the newest versions, and means that the `docker` and
+{product-title} processes have been restarted, which will force them to check
+that all of the rules in other services are correct.
++
+However, instead of rebooting a node host, you can restart the services that are
+affected, or preserve the `iptables` state. Both processes are described in the
 xref:../../admin_guide/iptables.adoc#admin-guide-iptables[{product-title}
 IPtables] topic. The `ovs` flow rules do not need to be saved, but restarting
 the {product-title} node software will fix the flow rules.
+
+. Configure the host to be schedulable again:
++
+----
+$ oadm manage-node <node_name> --schedulable=true
+----
+
+

--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -115,7 +115,7 @@ window.OPENSHIFT_EXTENSION_PROPERTIES = {
 ====
 
 [[customizing-the-logo]]
-=== Customizing the Logo
+== Customizing the Logo
 
 The following style changes the logo in the web console header:
 
@@ -142,7 +142,7 @@ assetConfig:
 ----
 
 [[changing-links-to-documentation]]
-=== Changing Links to Documentation
+== Changing Links to Documentation
 
 Links to external documentation are shown in various sections of the web
 console. The following example changes the URL for two given links to the
@@ -164,7 +164,7 @@ assetConfig:
 ----
 
 [[adding-or-changing-links-to-download-the-cli]]
-=== Adding or Changing Links to Download the CLI
+== Adding or Changing Links to Download the CLI
 
 The *About* page in the web console provides download links for the
 xref:../cli_reference/index.adoc#cli-reference-index[command line interface (CLI)] tools. These
@@ -250,9 +250,9 @@ assetConfig:
 ----
 
 [[configuring-navigation-menus]]
-=== Configuring Navigation Menus
+== Configuring Navigation Menus
 
-==== Top Navigation Dropdown Menus
+=== Top Navigation Dropdown Menus
 
 The top navigation bar of the web console contains the help icon and the user
 dropdown menus. You can add additional menu items to these using the
@@ -300,7 +300,7 @@ angular
 hawtioPluginLoader.addModule('<myExtensionModule>');
 ----
 
-==== Project Left Navigation
+=== Project Left Navigation
 
 When navigating within a project, a menu appears on the left with primary and
 secondary navigation. This menu structure is defined as a constant and can be
@@ -407,7 +407,7 @@ endif::[]
 endif::[]
 
 [[configuring-catalog-categories]]
-=== Configuring Catalog Categories
+== Configuring Catalog Categories
 
 Catalog categories organize the display of builder images and templates on the
 *Add to Project* page on the {product-title} web console. A builder image or
@@ -506,8 +506,58 @@ endif::[]
 
 endif::[]
 
+[[configuring-the-create-from-url-namespace-whitelist]]
+== Configuring the Create From URL Namespace Whitelist
+
+xref:../dev_guide/create_from_url.adoc#dev-guide-create-from-url[Create from URL]
+only works with image streams or templates from namespaces that have been
+explicitly specified in OPENSHIFT_CONSTANTS.CREATE_FROM_URL_WHITELIST.  To add
+namespaces to the whitelist, follow these steps:
+
+[NOTE]
+====
+'openshift' is included in the whitelist by default.  It should not be removed.
+====
+
+. Create the following configuration scripts within a file (for example,
+*_create-from-url-whitelist.js_*):
++
+====
+----
+// Add a namespace containing the image streams and/or templates
+window.OPENSHIFT_CONSTANTS.CREATE_FROM_URL_WHITELIST.push(
+  'shared-stuff'
+);
+----
+====
+
+. Save the file and add it to the master configuration at
+*_/etc/origin/master/master-config.yml_*:
++
+====
+----
+assetConfig:
+  ...
+  extensionScripts:
+    - /path/to/create-from-url-whitelist.js
+----
+====
+
+. Restart the master host:
++
+====
+ifdef::openshift-origin[]
+# systemctl restart origin-master
+endif::[]
+ifdef::openshift-enterprise[]
+# systemctl restart atomic-openshift-master
+endif::[]
+====
+
+endif::[]
+
 [[web-console-enable-wildcard-routes]]
-=== Enabling Wildcard Routes
+== Enabling Wildcard Routes
 
 If you enabled wildcard routes for a router, you can also enable wildcard
 routes in the web console. This lets users enter hostnames starting with an
@@ -532,7 +582,7 @@ xref:../install_config/router/default_haproxy_router.adoc#using-wildcard-routes[
 how to configure HAProxy routers to allow wildcard routes].
 
 [[web-console-enable-tech-preview-feature]]
-=== Enabling Features in Technology Preview
+== Enabling Features in Technology Preview
 
 Sometimes features are available in Technology Preview. By default, these
 features are disabled in the web console and hidden from end users.

--- a/install_config/web_console_customization.adoc
+++ b/install_config/web_console_customization.adoc
@@ -520,48 +520,44 @@ endif::[]
 
 xref:../dev_guide/create_from_url.adoc#dev-guide-create-from-url[Create from URL]
 only works with image streams or templates from namespaces that have been
-explicitly specified in OPENSHIFT_CONSTANTS.CREATE_FROM_URL_WHITELIST.  To add
+explicitly specified in `OPENSHIFT_CONSTANTS.CREATE_FROM_URL_WHITELIST`.  To add
 namespaces to the whitelist, follow these steps:
 
 [NOTE]
 ====
-'openshift' is included in the whitelist by default.  It should not be removed.
+`openshift` is included in the whitelist by default. Do not remove it.
 ====
 
 . Create the following configuration scripts within a file (for example,
 *_create-from-url-whitelist.js_*):
 +
-====
 ----
 // Add a namespace containing the image streams and/or templates
 window.OPENSHIFT_CONSTANTS.CREATE_FROM_URL_WHITELIST.push(
   'shared-stuff'
 );
 ----
-====
 
-. Save the file and add it to the master configuration at
+. Save the file and add it to the master configuration file at
 *_/etc/origin/master/master-config.yml_*:
 +
-====
 ----
 assetConfig:
   ...
   extensionScripts:
     - /path/to/create-from-url-whitelist.js
 ----
-====
 
 . Restart the master host:
 +
-====
+----
 ifdef::openshift-origin[]
 # systemctl restart origin-master
 endif::[]
 ifdef::openshift-enterprise[]
 # systemctl restart atomic-openshift-master
 endif::[]
-====
+----
 
 endif::[]
 

--- a/rest_api/kubernetes_v1.adoc
+++ b/rest_api/kubernetes_v1.adoc
@@ -11882,7 +11882,7 @@ PersistentVolumeSpec is the specification of a persistent volume.
 |hostPath|HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: http://releases.k8s.io/release-1.4/docs/user-guide/volumes.md#hostpath|false|<<v1.HostPathVolumeSource>>|
 |glusterfs|Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/release-1.4/examples/volumes/glusterfs/README.md|false|<<v1.GlusterfsVolumeSource>>|
 |nfs|NFS represents an NFS mount on the host. Provisioned by an admin. More info: http://releases.k8s.io/release-1.4/docs/user-guide/volumes.md#nfs|false|<<v1.NFSVolumeSource>>|
-|rbd|RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.4/examples/volumes/rbd/README.md|false|<<v1.RBDVolumeSource>>|
+|rbd|A Ceph Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.4/examples/volumes/rbd/README.md|false|<<v1.RBDVolumeSource>>|
 |iscsi|ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.|false|<<v1.ISCSIVolumeSource>>|
 |cinder|Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/release-1.4/examples/mysql-cinder-pd/README.md|false|<<v1.CinderVolumeSource>>|
 |cephfs|CephFS represents a Ceph FS mount on the host that shares a pod's lifetime|false|<<v1.CephFSVolumeSource>>|
@@ -12091,7 +12091,7 @@ Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do 
 
 === v1.RBDVolumeSource
 :hardbreaks:
-Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+Represents a Ceph Rados Block Device mount that lasts the lifetime of a pod. Ceph RBD volumes support ownership management and SELinux relabeling.
 
 [options="header"]
 |===
@@ -12552,7 +12552,7 @@ Volume represents a named volume in a pod that may be accessed by any container 
 |iscsi|ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.4/examples/volumes/iscsi/README.md|false|<<v1.ISCSIVolumeSource>>|
 |glusterfs|Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.4/examples/volumes/glusterfs/README.md|false|<<v1.GlusterfsVolumeSource>>|
 |persistentVolumeClaim|PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://releases.k8s.io/release-1.4/docs/user-guide/persistent-volumes.md#persistentvolumeclaims|false|<<v1.PersistentVolumeClaimVolumeSource>>|
-|rbd|RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.4/examples/volumes/rbd/README.md|false|<<v1.RBDVolumeSource>>|
+|rbd|A Ceph Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.4/examples/volumes/rbd/README.md|false|<<v1.RBDVolumeSource>>|
 |flexVolume|FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.|false|<<v1.FlexVolumeSource>>|
 |cinder|Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/release-1.4/examples/mysql-cinder-pd/README.md|false|<<v1.CinderVolumeSource>>|
 |cephfs|CephFS represents a Ceph FS mount on the host that shares a pod's lifetime|false|<<v1.CephFSVolumeSource>>|

--- a/rest_api/openshift_v1.adoc
+++ b/rest_api/openshift_v1.adoc
@@ -14004,7 +14004,7 @@ Image is an immutable representation of a Docker image and metadata at a point i
 |dockerImageManifest|DockerImageManifest is the raw JSON of the manifest|false|string|
 |dockerImageLayers|DockerImageLayers represents the layers in the image. May not be set if the image does not define that data.|true|<<v1.ImageLayer>> array|
 |signatures|Signatures holds all signatures of the image.|false|<<v1.ImageSignature>> array|
-|dockerImageSignatures|DockerImageSignatures provides the signatures as opaque blobs. This is a part of manifest schema v1.|false|<<v1.Image.dockerImageSignatures>> array|
+|dockerImageSignatures|DockerImageSignatures provides the signatures as opaque blobs.
 |dockerImageManifestMediaType|DockerImageManifestMediaType specifies the mediaType of manifest. This is a part of manifest schema v2.|false|string|
 |dockerImageConfig|DockerImageConfig is a JSON blob that the runtime uses to set up the container. This is a part of manifest schema v2.|false|string|
 |===

--- a/rest_api/openshift_v1.adoc
+++ b/rest_api/openshift_v1.adoc
@@ -15036,7 +15036,7 @@ Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do 
 
 === v1.RBDVolumeSource
 :hardbreaks:
-Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+Represents a Ceph Rados Block Device mount that lasts the lifetime of a pod. Ceph RBD volumes support ownership management and SELinux relabeling.
 
 [options="header"]
 |===
@@ -15817,7 +15817,7 @@ Volume represents a named volume in a pod that may be accessed by any container 
 |iscsi|ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.4/examples/volumes/iscsi/README.md|false|<<v1.ISCSIVolumeSource>>|
 |glusterfs|Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.4/examples/volumes/glusterfs/README.md|false|<<v1.GlusterfsVolumeSource>>|
 |persistentVolumeClaim|PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://releases.k8s.io/release-1.4/docs/user-guide/persistent-volumes.md#persistentvolumeclaims|false|<<v1.PersistentVolumeClaimVolumeSource>>|
-|rbd|RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.4/examples/volumes/rbd/README.md|false|<<v1.RBDVolumeSource>>|
+|rbd|A Ceph Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.4/examples/volumes/rbd/README.md|false|<<v1.RBDVolumeSource>>|
 |flexVolume|FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.|false|<<v1.FlexVolumeSource>>|
 |cinder|Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/release-1.4/examples/mysql-cinder-pd/README.md|false|<<v1.CinderVolumeSource>>|
 |cephfs|CephFS represents a Ceph FS mount on the host that shares a pod's lifetime|false|<<v1.CephFSVolumeSource>>|

--- a/using_images/s2i_images/dot_net_core.adoc
+++ b/using_images/s2i_images/dot_net_core.adoc
@@ -33,7 +33,7 @@ and Python from within {product-title}.
 [[dot-net-core-supported-versions]]
 == Supported Versions
 
-* .NET Core version 1.0
+* .NET Core version 1.1
 ** Supported on Red Hat Enterprise Linux (RHEL) 7
 ifdef::openshift-enterprise[]
 and {product-title} versions 3.3 and later
@@ -48,7 +48,7 @@ endif::openshift-enterprise[]
 The RHEL 7 images are available through Red Hat's subscription registry using:
 
 ----
-$ docker pull registry.access.redhat.com/dotnet/dotnetcore-10-rhel7
+$ docker pull registry.access.redhat.com/dotnet/dotnetcore-11-rhel7
 ----
 
 To use these images, you can either access them directly from these
@@ -82,7 +82,7 @@ An image can be used to build an application by running `oc new-app` against a
 sample repository:
 
 ----
-$ oc new-app https://github.com/redhat-developer/s2i-dotnetcore --context-dir=1.0/test/asp-net-hello-world
+$ oc new-app registry.access.redhat.com/dotnet/dotnetcore-11-rhel7~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-1.1 --context-dir=app
 ----
 
 ifdef::openshift-enterprise[]


### PR DESCRIPTION
related to this warning in the journal '...W0306 20:53:52.706793 106410 start_master.go:278] Warning: auditConfig.auditFilePath: Required value: audit can now be logged to a separate file, master start will continue.' I changed the first letter from capital to small. After this change it works well...
Audit log is activated and is logging into a defined file.